### PR TITLE
feat: Integrate AcoustID web service for ID lookup

### DIFF
--- a/amusic.ts
+++ b/amusic.ts
@@ -34,22 +34,32 @@ if (import.meta.main) {
   await new Command()
     .name("amusic")
     .version("0.1.0")
-    .description("Tag audio files with AcousticID fingerprints.")
+    .description("Tag audio files with AcousticID fingerprints and IDs.")
     .option("-f, --force", "Force reprocessing even if tags exist.")
     .option("-q, --quiet", "Suppress informational output. Errors are still shown.", { default: false })
+    .option("--api-key <key:string>", "AcoustID API key (required for lookups).")
     .arguments("<files:string...>")
     .action(async (options, ...files) => {
       await ensureCommandExists("fpcalc");
       await ensureCommandExists("ffprobe");
       await ensureCommandExists("ffmpeg");
 
+      if (!options.apiKey) {
+        console.error("Error: --api-key is required for AcoustID lookups.");
+        console.error("Please provide your AcoustID API key using the --api-key <key> option.");
+        Deno.exit(1);
+      }
+
       if (!options.quiet) {
         console.log(`Processing ${files.length} file(s)...`);
+        console.log(`Using API Key: ${options.apiKey.substring(0, 5)}...`); // Show a portion for confirmation
       }
 
       let processedCount = 0;
       let skippedCount = 0;
       let failedCount = 0;
+      let lookupFailedCount = 0;
+      let noResultsCount = 0;
 
       for (const file of files) {
         try {
@@ -58,7 +68,7 @@ if (import.meta.main) {
           // Adding a newline if not quiet for better separation if processAcoustIDTagging prints its header.
           if (!options.quiet && files.length > 1) console.log(""); // Add space between file logs
 
-          const status = await processAcoustIDTagging(file, options.force || false, options.quiet || false);
+          const status = await processAcoustIDTagging(file, options.apiKey, options.force || false, options.quiet || false);
           switch (status) {
             case "processed":
               processedCount++;
@@ -69,20 +79,34 @@ if (import.meta.main) {
             case "failed":
               failedCount++;
               break;
+            case "lookup_failed":
+              lookupFailedCount++;
+              // Consider if lookup_failed should also increment general `failedCount`
+              // For now, keeping them separate in count but maybe sum up for total errors later.
+              break;
+            case "no_results":
+              noResultsCount++;
+              break;
           }
         } catch (error) {
           // This catch block might be redundant if processAcoustIDTagging handles all its errors
           // and returns "failed". However, keeping it for unexpected errors.
           console.error(`Unexpected error processing ${file}: ${error.message}`);
-          failedCount++;
+          failedCount++; // General failures not caught by specific statuses
         }
       }
 
       // Print Summary Report
       console.log("\n--- Processing Complete ---");
       console.log(`Successfully processed: ${processedCount}`);
-      console.log(`Skipped: ${skippedCount}`);
-      console.log(`Failed: ${failedCount}`);
+      console.log(`Skipped (already tagged/force not used): ${skippedCount}`);
+      console.log(`No AcoustID results found: ${noResultsCount}`);
+      console.log(`AcoustID lookup failed (API/network issues): ${lookupFailedCount}`);
+      let otherFailures = failedCount; // Start with general failures
+      // If you decide lookup_failed also contributes to a total "Failed" count shown to user,
+      // you might sum them here or ensure `failedCount` is incremented alongside `lookupFailedCount`.
+      // For this example, let's assume `failedCount` is for errors not covered by `lookupFailedCount`.
+      console.log(`Other failures (e.g., file access, fpcalc): ${otherFailures}`);
       console.log("---------------------------");
     })
     .parse(Deno.args);


### PR DESCRIPTION
This commit introduces the functionality to query the AcoustID web service to fetch the `ACOUSTID_ID` based on a generated fingerprint.

Changes include:

- Added `lookupFingerprint` function to `lib/acoustid.ts` to interact with the AcoustID API (v2 lookup). It requires an API key, fingerprint, and audio duration.
- Replaced `writeAcousticIDFingerprint` with `writeAcoustIDTags` in `lib/acoustid.ts` to write both `ACOUSTID_FINGERPRINT` and `ACOUSTID_ID` to file metadata using ffmpeg.
- Modified `processAcoustIDTagging` in `lib/acoustid.ts` to:
    - Accept an API key.
    - Fetch audio duration using ffprobe.
    - Call `lookupFingerprint` to retrieve the `ACOUSTID_ID`.
    - Call `writeAcoustIDTags` with both fingerprint and ID.
    - Handle new result statuses: `lookup_failed` and `no_results`.
- Updated `amusic.ts` CLI to:
    - Accept a new required `--api-key` option.
    - Pass the API key to `processAcoustIDTagging`.
    - Provide more detailed summary reporting, including lookup failures and no-result cases.
- Updated `lib/acoustid.test.ts`:
    - Added comprehensive tests for `lookupFingerprint`, mocking API calls and various response scenarios.
    - Modified tests for `writeAcousticIDFingerprint` to target `writeAcoustIDTags`, ensuring both tags are correctly passed to ffmpeg.
    - Enhanced the internal `MockDenoCommand` to capture command arguments for more precise testing.

The AcoustID application API key provided in the issue (`aiNOlIIqT9`) is expected to be passed via the `--api-key` command-line argument.