### PR TITLE
feat: Add --show-tags and --dry-run options for AcoustID processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ deno run --allow-read --allow-run --allow-write --allow-env amusic.ts [options] 
   files with existing tags will be skipped.
 - `-q, --quiet`: Suppress informational output during processing. Error messages
   and the final summary report will still be displayed.
+- `--show-tags`: Display existing `ACOUSTID_ID` and `ACOUSTID_FINGERPRINT`
+  tags for the specified files and then exit. This option does not modify
+  files or perform any online lookups.
+- `--dry-run`: Simulate the entire tagging process, including fingerprint
+  generation and AcoustID API lookups (if an `--api-key` is provided), but
+  do not make any actual changes to the audio files. This is useful for
+  testing or previewing what actions would be performed. A notice will be
+  shown in the summary report if a dry run was performed.
 
 After processing all files, a summary report is displayed, showing the number of
 files successfully processed, skipped, and failed.


### PR DESCRIPTION
This commit introduces two new command-line options to the amusic tool:

1.  `--show-tags`: Allows you to display any existing `ACOUSTID_ID` and `ACOUSTID_FINGERPRINT` tags for the specified audio files. The tool will print the tags and then exit, without performing any modifications or AcoustID lookups. If no tags are found, it will indicate this.

2.  `--dry-run`: Enables you to simulate the entire AcoustID tagging process (including fingerprint generation and API lookups if an API key is provided) without actually writing any changes to the audio files. The output will indicate the actions that would have been taken, and the summary report will note that it was a dry run. This is useful for testing or previewing the tool's behavior.

These options enhance the tool's utility by providing more control and information to you.

The implementation includes:
- Updates to the command-line interface parsing in `src/amusic.ts`.
- Logic in `src/lib/acoustid.ts` to support tag display and to skip tag writing during a dry run.
- Comprehensive integration tests in `src/amusic.test.ts` covering various scenarios for both new options.
- Updated `README.md` to document the new options.